### PR TITLE
[vagrant] Create Vagrantfile to deploy the Graylog production infrastructure

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,109 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider "virtualbox" do |vb|
+     vb.memory = "512"
+  end
+  
+  config.vm.define "elasticsearch_node1" do |node1|
+    node1.vm.hostname = "node1"
+    node1.vm.network "private_network", ip: "10.0.0.10"
+
+    node1.vm.provision "docker" do |d|
+      d.run "elasticsearch_node1",
+        image: "jorgeacetozi/elasticsearch:2.3.5",
+        args: "--net=host \
+               --privileged \
+               -e CLUSTER_NAME=graylog \
+               -e NODE_NAME=node1 \
+               -e LOCK_MEMORY=true \
+               --ulimit memlock=-1:-1 \
+               --ulimit nofile=65536:65536 \
+               -e NETWORK_HOST=10.0.0.10 \
+               -e UNICAST_HOSTS='10.0.0.10:9300, 10.0.0.20:9300' \
+               -e ES_HEAP_SIZE=256m"
+    end
+  end
+
+  config.vm.define "elasticsearch_node2" do |node2|
+    node2.vm.hostname = "node2"
+    node2.vm.network "private_network", ip: "10.0.0.20"
+
+    node2.vm.provision "docker" do |d|
+      d.run "elasticsearch_node2",
+        image: "jorgeacetozi/elasticsearch:2.3.5",
+        args: "--net=host \
+               --privileged \
+               -e CLUSTER_NAME=graylog \
+               -e NODE_NAME=node2 \
+               -e LOCK_MEMORY=true \
+               --ulimit memlock=-1:-1 \
+               --ulimit nofile=65536:65536 \
+               -e NETWORK_HOST=10.0.0.20 \
+               -e UNICAST_HOSTS='10.0.0.10:9300, 10.0.0.20:9300' \
+               -e ES_HEAP_SIZE=256m"
+    end
+  end
+
+  config.vm.define "mongo" do |mongo|
+    mongo.vm.hostname = "mongo"
+    mongo.vm.network "private_network", ip: "10.0.0.30"
+
+    mongo.vm.provision "docker" do |d|
+      d.run "mongo",
+        image: "mongo",
+        args: "-p 27017:27017"
+    end
+  end
+
+  config.vm.define "graylog_master" do |graylog_master|
+    graylog_master.vm.hostname = "master"
+    graylog_master.vm.network "private_network", ip: "10.0.0.40"
+    graylog_master.vm.provider "virtualbox" do |vb|
+      vb.memory = "2048"
+    end
+
+    graylog_master.vm.provision "docker" do |d|
+      d.run "graylog",
+        image: "jorgeacetozi/graylog:2.2.3",
+        args: "--net=host \
+               -p 12201:12201/udp \
+               -v '/vagrant/conf/graylog-server-master/graylog.conf:/etc/graylog/server/server.conf'"
+    end
+  end
+
+  config.vm.define "graylog_slave" do |graylog_slave|
+    graylog_slave.vm.hostname = "slave"
+    graylog_slave.vm.network "private_network", ip: "10.0.0.50"
+    graylog_slave.vm.provider "virtualbox" do |vb|
+      vb.memory = "2048"
+    end
+
+    graylog_slave.vm.provision "docker" do |d|
+      d.run "graylog",
+        image: "jorgeacetozi/graylog:2.2.3",
+        args: "--net=host \
+               -p 12201:12201/udp \
+               -v '/vagrant/conf/graylog-server-slave/graylog.conf:/etc/graylog/server/server.conf'"
+    end
+  end
+
+  config.vm.define "nginx" do |nginx|
+    nginx.vm.hostname = "nginx"
+    nginx.vm.network "private_network", ip: "10.0.0.5"
+
+    # Cannot bind to 80 on host
+    nginx.vm.network "forwarded_port", guest: 80, host: 8080
+
+    nginx.vm.provision "docker" do |d|
+      d.run "nginx",
+        image: "nginx",
+        args: "-p 80:80 \
+               -p 12201:12201/udp \
+               -v '/vagrant/conf/nginx/nginx.conf:/etc/nginx/nginx.conf:ro'"
+    end
+  end
+end

--- a/vagrant/conf/graylog-server-master/graylog.conf
+++ b/vagrant/conf/graylog-server-master/graylog.conf
@@ -1,0 +1,554 @@
+############################
+# GRAYLOG CONFIGURATION FILE
+############################
+#
+# This is the Graylog configuration file. The file has to use ISO 8859-1/Latin-1 character encoding.
+# Characters that cannot be directly represented in this encoding can be written using Unicode escapes
+# as defined in https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3, using the \u prefix.
+# For example, \u002c.
+# 
+# * Entries are generally expected to be a single line of the form, one of the following:
+#
+# propertyName=propertyValue
+# propertyName:propertyValue
+#
+# * White space that appears between the property name and property value is ignored,
+#   so the following are equivalent:
+# 
+# name=Stephen
+# name = Stephen
+#
+# * White space at the beginning of the line is also ignored.
+#
+# * Lines that start with the comment characters ! or # are ignored. Blank lines are also ignored.
+#
+# * The property value is generally terminated by the end of the line. White space following the
+#   property value is not ignored, and is treated as part of the property value.
+#
+# * A property value can span several lines if each line is terminated by a backslash (‘\’) character.
+#   For example:
+#
+# targetCities=\
+#         Detroit,\
+#         Chicago,\
+#         Los Angeles
+#
+#   This is equivalent to targetCities=Detroit,Chicago,Los Angeles (white space at the beginning of lines is ignored).
+# 
+# * The characters newline, carriage return, and tab can be inserted with characters \n, \r, and \t, respectively.
+# 
+# * The backslash character must be escaped as a double backslash. For example:
+# 
+# path=c:\\docs\\doc1
+#
+
+# If you are running more than one instances of Graylog server you have to select one of these
+# instances as master. The master will perform some periodical tasks that non-masters won't perform.
+is_master = true
+
+# The auto-generated node ID will be stored in this file and read after restarts. It is a good idea
+# to use an absolute file path here if you are starting Graylog server from init scripts or similar.
+node_id_file = /etc/graylog/server/node-id
+
+# You MUST set a secret to secure/pepper the stored user passwords here. Use at least 64 characters.
+# Generate one by using for example: pwgen -N 1 -s 96
+password_secret = aLQAJN8ot1bGQe4G7aUwbSwsmrLJFs1H4I3aSKvyAKjcttYalnKLg3EcAMDBmCpBGXacfhdReXvSyz6QlYnfIxsE4HiURaJa
+
+# The default root user is named 'admin'
+#root_username = admin
+
+# You MUST specify a hash password for the root user (which you only need to initially set up the
+# system and in case you lose connectivity to your authentication backend)
+# This password cannot be changed using the API or via the web interface. If you need to change it,
+# modify it in this file.
+# Create one by using for example: echo -n yourpassword | shasum -a 256
+# and put the resulting hash value into the following line
+root_password_sha2 = e4d41b63ecf192b34e43542606f6ac2f15c44465acf0aa8c7b6ef77104ee9546
+
+# The email address of the root user.
+# Default is empty
+root_email = "jorge.acetozi@gmail.com"
+
+# The time zone setting of the root user. See http://www.joda.org/joda-time/timezones.html for a list of valid time zones.
+# Default is UTC
+#root_timezone = UTC
+
+# Set plugin directory here (relative or absolute)
+plugin_dir = plugin
+
+# REST API listen URI. Must be reachable by other Graylog server nodes if you run a cluster.
+# When using Graylog Collectors, this URI will be used to receive heartbeat messages and must be accessible for all collectors.
+rest_listen_uri = http://10.0.0.40:9000/api/
+
+# REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri
+# is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
+# If set, this will be promoted in the cluster discovery APIs, so other nodes may try to connect on
+# this address and it is used to generate URLs addressing entities in the REST API. (see rest_listen_uri)
+# You will need to define this, if your Graylog server is running behind a HTTP proxy that is rewriting
+# the scheme, host name or URI.
+# This must not contain a wildcard address (0.0.0.0).
+#rest_transport_uri = http://192.168.1.1:9000/api/
+
+# Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.
+# If these are disabled, modern browsers will not be able to retrieve resources from the server.
+# This is enabled by default. Uncomment the next line to disable it.
+#rest_enable_cors = false
+
+# Enable GZIP support for REST API. This compresses API responses and therefore helps to reduce
+# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
+#rest_enable_gzip = false
+
+# Enable HTTPS support for the REST API. This secures the communication with the REST API with
+# TLS to prevent request forgery and eavesdropping. This is disabled by default. Uncomment the
+# next line to enable it.
+#rest_enable_tls = true
+
+# The X.509 certificate chain file in PEM format to use for securing the REST API.
+#rest_tls_cert_file = /path/to/graylog.crt
+
+# The PKCS#8 private key file in PEM format to use for securing the REST API.
+#rest_tls_key_file = /path/to/graylog.key
+
+# The password to unlock the private key used for securing the REST API.
+#rest_tls_key_password = secret
+
+# The maximum size of the HTTP request headers in bytes.
+#rest_max_header_size = 8192
+
+# The maximal length of the initial HTTP/1.1 line in bytes.
+#rest_max_initial_line_length = 4096
+
+# The size of the thread pool used exclusively for serving the REST API.
+#rest_thread_pool_size = 16
+
+# Comma separated list of trusted proxies that are allowed to set the client address with X-Forwarded-For
+# header. May be subnets, or hosts.
+#trusted_proxies = 127.0.0.1/32, 0:0:0:0:0:0:0:1/128
+
+# Enable the embedded Graylog web interface.
+# Default: true
+#web_enable = false
+
+# Web interface listen URI.
+# Configuring a path for the URI here effectively prefixes all URIs in the web interface. This is a replacement
+# for the application.context configuration parameter in pre-2.0 versions of the Graylog web interface.
+web_listen_uri = http://10.0.0.40:9000/
+
+# Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
+# Default: $rest_transport_uri
+#web_endpoint_uri =
+
+# Enable CORS headers for the web interface. This is necessary for JS-clients accessing the server directly.
+# If these are disabled, modern browsers will not be able to retrieve resources from the server.
+#web_enable_cors = false
+
+# Enable/disable GZIP support for the web interface. This compresses HTTP responses and therefore helps to reduce
+# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
+#web_enable_gzip = false
+
+# Enable HTTPS support for the web interface. This secures the communication of the web browser with the web interface
+# using TLS to prevent request forgery and eavesdropping.
+# This is disabled by default. Uncomment the next line to enable it and see the other related configuration settings.
+#web_enable_tls = true
+
+# The X.509 certificate chain file in PEM format to use for securing the web interface.
+#web_tls_cert_file = /path/to/graylog-web.crt
+
+# The PKCS#8 private key file in PEM format to use for securing the web interface.
+#web_tls_key_file = /path/to/graylog-web.key
+
+# The password to unlock the private key used for securing the web interface.
+#web_tls_key_password = secret
+
+# The maximum size of the HTTP request headers in bytes.
+#web_max_header_size = 8192
+
+# The maximal length of the initial HTTP/1.1 line in bytes.
+#web_max_initial_line_length = 4096
+
+# The size of the thread pool used exclusively for serving the web interface.
+#web_thread_pool_size = 16
+
+# Configuration file for the embedded Elasticsearch instance in Graylog.
+# Pay attention to the working directory of the server, maybe use an absolute path here.
+# Default: empty
+#elasticsearch_config_file = /etc/graylog/server/elasticsearch.yml
+
+# Graylog will use multiple indices to store documents in. You can configured the strategy it uses to determine
+# when to rotate the currently active write index.
+# It supports multiple rotation strategies:
+#   - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
+#   - "size" per index, use elasticsearch_max_size_per_index below to configure
+# valid values are "count", "size" and "time", default is "count"
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+rotation_strategy = count
+
+# (Approximate) maximum number of documents in an Elasticsearch index before a new index
+# is being created, also see no_retention and elasticsearch_max_number_of_indices.
+# Configure this if you used 'rotation_strategy = count' above.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+elasticsearch_max_docs_per_index = 20000000
+
+# (Approximate) maximum size in bytes per Elasticsearch index on disk before a new index is being created, also see
+# no_retention and elasticsearch_max_number_of_indices. Default is 1GB.
+# Configure this if you used 'rotation_strategy = size' above.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+#elasticsearch_max_size_per_index = 1073741824
+
+# (Approximate) maximum time before a new Elasticsearch index is being created, also see
+# no_retention and elasticsearch_max_number_of_indices. Default is 1 day.
+# Configure this if you used 'rotation_strategy = time' above.
+# Please note that this rotation period does not look at the time specified in the received messages, but is
+# using the real clock value to decide when to rotate the index!
+# Specify the time using a duration and a suffix indicating which unit you want:
+#  1w  = 1 week
+#  1d  = 1 day
+#  12h = 12 hours
+# Permitted suffixes are: d for day, h for hour, m for minute, s for second.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+#elasticsearch_max_time_per_index = 1d
+
+# Disable checking the version of Elasticsearch for being compatible with this Graylog release.
+# WARNING: Using Graylog with unsupported and untested versions of Elasticsearch may lead to data loss!
+#elasticsearch_disable_version_check = true
+
+# Disable message retention on this node, i. e. disable Elasticsearch index rotation.
+#no_retention = false
+
+# How many indices do you want to keep?
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+elasticsearch_max_number_of_indices = 20
+
+# Decide what happens with the oldest indices when the maximum number of indices is reached.
+# The following strategies are availble:
+#   - delete # Deletes the index completely (Default)
+#   - close # Closes the index and hides it from the system. Can be re-opened later.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+retention_strategy = delete
+
+# How many Elasticsearch shards and replicas should be used per index? Note that this only applies to newly created indices.
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+elasticsearch_shards = 4
+elasticsearch_replicas = 1
+
+# Prefix for all Elasticsearch indices and index aliases managed by Graylog.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+elasticsearch_index_prefix = graylog
+
+# Name of the Elasticsearch index template used by Graylog to apply the mandatory index mapping.
+# Default: graylog-internal
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+#elasticsearch_template_name = graylog-internal
+
+# Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only
+# be enabled with care. See also: http://docs.graylog.org/en/2.1/pages/queries.html
+allow_leading_wildcard_searches = false
+
+# Do you want to allow searches to be highlighted? Depending on the size of your messages this can be memory hungry and
+# should only be enabled after making sure your Elasticsearch cluster has enough memory.
+allow_highlighting = false
+
+# settings to be passed to elasticsearch's client (overriding those in the provided elasticsearch_config_file)
+# all these
+# this must be the same as for your Elasticsearch cluster
+elasticsearch_cluster_name = graylog
+
+# The prefix being used to generate the Elasticsearch node name which makes it easier to identify the specific Graylog
+# server running the embedded Elasticsearch instance. The node name will be constructed by concatenating this prefix
+# and the Graylog node ID (see node_id_file), for example "graylog-17052010-1234-5678-abcd-1337cafebabe".
+# Default: graylog-
+#elasticsearch_node_name_prefix = graylog-
+
+# A comma-separated list of Elasticsearch nodes which Graylog is using to connect to the Elasticsearch cluster,
+# see https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-discovery-zen.html for details.
+# Default: 127.0.0.1
+elasticsearch_discovery_zen_ping_unicast_hosts = 10.0.0.10, 10.0.0.20
+
+# Use multiple Elasticsearch nodes as seed
+elasticsearch_discovery_zen_ping_unicast_hosts = 10.0.0.10:9300, 10.0.0.20:9300
+
+# we don't want the Graylog server to store any data, or be master node
+#elasticsearch_node_master = false
+#elasticsearch_node_data = false
+
+# use a different port if you run multiple Elasticsearch nodes on one machine
+elasticsearch_transport_tcp_port = 9300
+
+# we don't need to run the embedded HTTP server here
+#elasticsearch_http_enabled = false
+
+# Change the following setting if you are running into problems with timeouts during Elasticsearch cluster discovery.
+# The setting is specified in milliseconds, the default is 5000ms (5 seconds).
+#elasticsearch_cluster_discovery_timeout = 5000
+
+# the following settings allow to change the bind addresses for the Elasticsearch client in Graylog
+# these settings are empty by default, letting Elasticsearch choose automatically,
+# override them here or in the 'elasticsearch_config_file' if you need to bind to a special address
+# refer to https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-network.html
+# for special values here
+elasticsearch_network_host = 10.0.0.40
+#elasticsearch_network_bind_host = 
+#elasticsearch_network_publish_host = 
+
+# The total amount of time discovery will look for other Elasticsearch nodes in the cluster
+# before giving up and declaring the current node master.
+#elasticsearch_discovery_initial_state_timeout = 3s
+
+# Analyzer (tokenizer) to use for message and full_message field. The "standard" filter usually is a good idea.
+# All supported analyzers are: standard, simple, whitespace, stop, keyword, pattern, language, snowball, custom
+# Elasticsearch documentation: https://www.elastic.co/guide/en/elasticsearch/reference/2.3/analysis.html
+# Note that this setting only takes effect on newly created indices.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+elasticsearch_analyzer = standard
+
+# Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
+# calculations) based on a best-effort to restrict the runtime of Elasticsearch operations.
+# Default: 1m
+#elasticsearch_request_timeout = 1m
+
+# Global timeout for index optimization (force merge) requests.
+# Default: 1h
+#elasticsearch_index_optimization_timeout = 1h
+
+# Maximum number of concurrently running index optimization (force merge) jobs.
+# If you are using lots of different index sets, you might want to increase that number.
+# Default: 20
+#elasticsearch_index_optimization_jobs = 20
+
+# Time interval for index range information cleanups. This setting defines how often stale index range information
+# is being purged from the database.
+# Default: 1h
+#index_ranges_cleanup_interval = 1h
+
+# Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
+# module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been
+# reached within output_flush_interval seconds, everything that is available will be flushed at once. Remember
+# that every outputbuffer processor manages its own batch and performs its own batch write calls.
+# ("outputbuffer_processors" variable)
+output_batch_size = 500
+
+# Flush interval (in seconds) for the Elasticsearch output. This is the maximum amount of time between two
+# batches of messages written to Elasticsearch. It is only effective at all if your minimum number of messages
+# for this time period is less than output_batch_size * outputbuffer_processors.
+output_flush_interval = 1
+
+# As stream outputs are loaded only on demand, an output which is failing to initialize will be tried over and
+# over again. To prevent this, the following configuration options define after how many faults an output will
+# not be tried again for an also configurable amount of seconds.
+output_fault_count_threshold = 5
+output_fault_penalty_seconds = 30
+
+# The number of parallel running processors.
+# Raise this number if your buffers are filling up.
+processbuffer_processors = 5
+outputbuffer_processors = 3
+
+#outputbuffer_processor_keep_alive_time = 5000
+#outputbuffer_processor_threads_core_pool_size = 3
+#outputbuffer_processor_threads_max_pool_size = 30
+
+# UDP receive buffer size for all message inputs (e. g. SyslogUDPInput).
+#udp_recvbuffer_sizes = 1048576
+
+# Wait strategy describing how buffer processors wait on a cursor sequence. (default: sleeping)
+# Possible types:
+#  - yielding
+#     Compromise between performance and CPU usage.
+#  - sleeping
+#     Compromise between performance and CPU usage. Latency spikes can occur after quiet periods.
+#  - blocking
+#     High throughput, low latency, higher CPU usage.
+#  - busy_spinning
+#     Avoids syscalls which could introduce latency jitter. Best when threads can be bound to specific CPU cores.
+processor_wait_strategy = blocking
+
+# Size of internal ring buffers. Raise this if raising outputbuffer_processors does not help anymore.
+# For optimum performance your LogMessage objects in the ring buffer should fit in your CPU L3 cache.
+# Must be a power of 2. (512, 1024, 2048, ...)
+ring_size = 65536
+
+inputbuffer_ring_size = 65536
+inputbuffer_processors = 2
+inputbuffer_wait_strategy = blocking
+
+# Enable the disk based message journal.
+message_journal_enabled = true
+
+# The directory which will be used to store the message journal. The directory must me exclusively used by Graylog and
+# must not contain any other files than the ones created by Graylog itself.
+#
+# ATTENTION:
+#   If you create a seperate partition for the journal files and use a file system creating directories like 'lost+found'
+#   in the root directory, you need to create a sub directory for your journal.
+#   Otherwise Graylog will log an error message that the journal is corrupt and Graylog will not start.
+message_journal_dir = data/journal
+
+# Journal hold messages before they could be written to Elasticsearch.
+# For a maximum of 12 hours or 5 GB whichever happens first.
+# During normal operation the journal will be smaller.
+#message_journal_max_age = 12h
+#message_journal_max_size = 5gb
+
+#message_journal_flush_age = 1m
+#message_journal_flush_interval = 1000000
+#message_journal_segment_age = 1h
+#message_journal_segment_size = 100mb
+
+# Number of threads used exclusively for dispatching internal events. Default is 2.
+#async_eventbus_processors = 2
+
+# How many seconds to wait between marking node as DEAD for possible load balancers and starting the actual
+# shutdown process. Set to 0 if you have no status checking load balancers in front.
+lb_recognition_period_seconds = 3
+
+# Journal usage percentage that triggers requesting throttling for this server node from load balancers. The feature is
+# disabled if not set.
+#lb_throttle_threshold_percentage = 95
+
+# Every message is matched against the configured streams and it can happen that a stream contains rules which
+# take an unusual amount of time to run, for example if its using regular expressions that perform excessive backtracking.
+# This will impact the processing of the entire server. To keep such misbehaving stream rules from impacting other
+# streams, Graylog limits the execution time for each stream.
+# The default values are noted below, the timeout is in milliseconds.
+# If the stream matching for one stream took longer than the timeout value, and this happened more than "max_faults" times
+# that stream is disabled and a notification is shown in the web interface.
+#stream_processing_timeout = 2000
+#stream_processing_max_faults = 3
+
+# Length of the interval in seconds in which the alert conditions for all streams should be checked
+# and alarms are being sent.
+#alert_check_interval = 60
+
+# Since 0.21 the Graylog server supports pluggable output modules. This means a single message can be written to multiple
+# outputs. The next setting defines the timeout for a single output module, including the default output module where all
+# messages end up.
+#
+# Time in milliseconds to wait for all message outputs to finish writing a single message.
+#output_module_timeout = 10000
+
+# Time in milliseconds after which a detected stale master node is being rechecked on startup.
+#stale_master_timeout = 2000
+
+# Time in milliseconds which Graylog is waiting for all threads to stop on shutdown.
+#shutdown_timeout = 30000
+
+# MongoDB connection string
+# See https://docs.mongodb.com/manual/reference/connection-string/ for details
+mongodb_uri = mongodb://10.0.0.30:27017/graylog
+
+# Authenticate against the MongoDB server
+#mongodb_uri = mongodb://grayloguser:secret@localhost:27017/graylog
+
+# Use a replica set instead of a single host
+#mongodb_uri = mongodb://grayloguser:secret@localhost:27017,localhost:27018,localhost:27019/graylog
+
+# Increase this value according to the maximum connections your MongoDB server can handle from a single client
+# if you encounter MongoDB connection problems.
+mongodb_max_connections = 1000
+
+# Number of threads allowed to be blocked by MongoDB connections multiplier. Default: 5
+# If mongodb_max_connections is 100, and mongodb_threads_allowed_to_block_multiplier is 5,
+# then 500 threads can block. More than that and an exception will be thrown.
+# http://api.mongodb.com/java/current/com/mongodb/MongoOptions.html#threadsAllowedToBlockForConnectionMultiplier
+mongodb_threads_allowed_to_block_multiplier = 5
+
+# Drools Rule File (Use to rewrite incoming log messages)
+# See: http://docs.graylog.org/en/2.1/pages/drools.html
+#rules_file = /etc/graylog/server/rules.drl
+
+# Email transport
+#transport_email_enabled = false
+#transport_email_hostname = mail.example.com
+#transport_email_port = 587
+#transport_email_use_auth = true
+#transport_email_use_tls = true
+#transport_email_use_ssl = true
+#transport_email_auth_username = you@example.com
+#transport_email_auth_password = secret
+#transport_email_subject_prefix = [graylog]
+#transport_email_from_email = graylog@example.com
+
+# Specify and uncomment this if you want to include links to the stream in your stream alert mails.
+# This should define the fully qualified base url to your web interface exactly the same way as it is accessed by your users.
+#transport_email_web_interface_url = https://graylog.example.com
+
+# The default connect timeout for outgoing HTTP connections.
+# Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).
+# Default: 5s
+#http_connect_timeout = 5s
+
+# The default read timeout for outgoing HTTP connections.
+# Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).
+# Default: 10s
+#http_read_timeout = 10s
+
+# The default write timeout for outgoing HTTP connections.
+# Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).
+# Default: 10s
+#http_write_timeout = 10s
+
+# HTTP proxy for outgoing HTTP connections
+#http_proxy_uri =
+
+# Disable the optimization of Elasticsearch indices after index cycling. This may take some load from Elasticsearch
+# on heavily used systems with large indices, but it will decrease search performance. The default is to optimize
+# cycled indices.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+#disable_index_optimization = true
+
+# Optimize the index down to <= index_optimization_max_num_segments. A higher number may take some load from Elasticsearch
+# on heavily used systems with large indices, but it will decrease search performance. The default is 1.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+#index_optimization_max_num_segments = 1
+
+# The threshold of the garbage collection runs. If GC runs take longer than this threshold, a system notification
+# will be generated to warn the administrator about possible problems with the system. Default is 1 second.
+#gc_warning_threshold = 1s
+
+# Connection timeout for a configured LDAP server (e. g. ActiveDirectory) in milliseconds.
+#ldap_connection_timeout = 2000
+
+# Disable the use of SIGAR for collecting system stats
+#disable_sigar = false
+
+# The default cache time for dashboard widgets. (Default: 10 seconds, minimum: 1 second)
+#dashboard_widget_default_cache_time = 10s
+
+# Automatically load content packs in "content_packs_dir" on the first start of Graylog.
+#content_packs_loader_enabled = true
+
+# The directory which contains content packs which should be loaded on the first start of Graylog.
+#content_packs_dir = data/contentpacks
+
+# A comma-separated list of content packs (files in "content_packs_dir") which should be applied on
+# the first start of Graylog.
+# Default: empty
+content_packs_auto_load = grok-patterns.json
+
+# For some cluster-related REST requests, the node must query all other nodes in the cluster. This is the maximum number
+# of threads available for this. Increase it, if '/cluster/*' requests take long to complete.
+# Should be rest_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
+proxied_requests_thread_pool_size = 32

--- a/vagrant/conf/graylog-server-slave/graylog.conf
+++ b/vagrant/conf/graylog-server-slave/graylog.conf
@@ -1,0 +1,554 @@
+############################
+# GRAYLOG CONFIGURATION FILE
+############################
+#
+# This is the Graylog configuration file. The file has to use ISO 8859-1/Latin-1 character encoding.
+# Characters that cannot be directly represented in this encoding can be written using Unicode escapes
+# as defined in https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3, using the \u prefix.
+# For example, \u002c.
+# 
+# * Entries are generally expected to be a single line of the form, one of the following:
+#
+# propertyName=propertyValue
+# propertyName:propertyValue
+#
+# * White space that appears between the property name and property value is ignored,
+#   so the following are equivalent:
+# 
+# name=Stephen
+# name = Stephen
+#
+# * White space at the beginning of the line is also ignored.
+#
+# * Lines that start with the comment characters ! or # are ignored. Blank lines are also ignored.
+#
+# * The property value is generally terminated by the end of the line. White space following the
+#   property value is not ignored, and is treated as part of the property value.
+#
+# * A property value can span several lines if each line is terminated by a backslash (‘\’) character.
+#   For example:
+#
+# targetCities=\
+#         Detroit,\
+#         Chicago,\
+#         Los Angeles
+#
+#   This is equivalent to targetCities=Detroit,Chicago,Los Angeles (white space at the beginning of lines is ignored).
+# 
+# * The characters newline, carriage return, and tab can be inserted with characters \n, \r, and \t, respectively.
+# 
+# * The backslash character must be escaped as a double backslash. For example:
+# 
+# path=c:\\docs\\doc1
+#
+
+# If you are running more than one instances of Graylog server you have to select one of these
+# instances as master. The master will perform some periodical tasks that non-masters won't perform.
+is_master = false
+
+# The auto-generated node ID will be stored in this file and read after restarts. It is a good idea
+# to use an absolute file path here if you are starting Graylog server from init scripts or similar.
+node_id_file = /etc/graylog/server/node-id
+
+# You MUST set a secret to secure/pepper the stored user passwords here. Use at least 64 characters.
+# Generate one by using for example: pwgen -N 1 -s 96
+password_secret = aLQAJN8ot1bGQe4G7aUwbSwsmrLJFs1H4I3aSKvyAKjcttYalnKLg3EcAMDBmCpBGXacfhdReXvSyz6QlYnfIxsE4HiURaJa
+
+# The default root user is named 'admin'
+#root_username = admin
+
+# You MUST specify a hash password for the root user (which you only need to initially set up the
+# system and in case you lose connectivity to your authentication backend)
+# This password cannot be changed using the API or via the web interface. If you need to change it,
+# modify it in this file.
+# Create one by using for example: echo -n yourpassword | shasum -a 256
+# and put the resulting hash value into the following line
+root_password_sha2 = e4d41b63ecf192b34e43542606f6ac2f15c44465acf0aa8c7b6ef77104ee9546
+
+# The email address of the root user.
+# Default is empty
+root_email = "jorge.acetozi@gmail.com"
+
+# The time zone setting of the root user. See http://www.joda.org/joda-time/timezones.html for a list of valid time zones.
+# Default is UTC
+#root_timezone = UTC
+
+# Set plugin directory here (relative or absolute)
+plugin_dir = plugin
+
+# REST API listen URI. Must be reachable by other Graylog server nodes if you run a cluster.
+# When using Graylog Collectors, this URI will be used to receive heartbeat messages and must be accessible for all collectors.
+rest_listen_uri = http://10.0.0.50:9000/api/
+
+# REST API transport address. Defaults to the value of rest_listen_uri. Exception: If rest_listen_uri
+# is set to a wildcard IP address (0.0.0.0) the first non-loopback IPv4 system address is used.
+# If set, this will be promoted in the cluster discovery APIs, so other nodes may try to connect on
+# this address and it is used to generate URLs addressing entities in the REST API. (see rest_listen_uri)
+# You will need to define this, if your Graylog server is running behind a HTTP proxy that is rewriting
+# the scheme, host name or URI.
+# This must not contain a wildcard address (0.0.0.0).
+#rest_transport_uri = http://192.168.1.1:9000/api/
+
+# Enable CORS headers for REST API. This is necessary for JS-clients accessing the server directly.
+# If these are disabled, modern browsers will not be able to retrieve resources from the server.
+# This is enabled by default. Uncomment the next line to disable it.
+#rest_enable_cors = false
+
+# Enable GZIP support for REST API. This compresses API responses and therefore helps to reduce
+# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
+#rest_enable_gzip = false
+
+# Enable HTTPS support for the REST API. This secures the communication with the REST API with
+# TLS to prevent request forgery and eavesdropping. This is disabled by default. Uncomment the
+# next line to enable it.
+#rest_enable_tls = true
+
+# The X.509 certificate chain file in PEM format to use for securing the REST API.
+#rest_tls_cert_file = /path/to/graylog.crt
+
+# The PKCS#8 private key file in PEM format to use for securing the REST API.
+#rest_tls_key_file = /path/to/graylog.key
+
+# The password to unlock the private key used for securing the REST API.
+#rest_tls_key_password = secret
+
+# The maximum size of the HTTP request headers in bytes.
+#rest_max_header_size = 8192
+
+# The maximal length of the initial HTTP/1.1 line in bytes.
+#rest_max_initial_line_length = 4096
+
+# The size of the thread pool used exclusively for serving the REST API.
+#rest_thread_pool_size = 16
+
+# Comma separated list of trusted proxies that are allowed to set the client address with X-Forwarded-For
+# header. May be subnets, or hosts.
+#trusted_proxies = 127.0.0.1/32, 0:0:0:0:0:0:0:1/128
+
+# Enable the embedded Graylog web interface.
+# Default: true
+#web_enable = false
+
+# Web interface listen URI.
+# Configuring a path for the URI here effectively prefixes all URIs in the web interface. This is a replacement
+# for the application.context configuration parameter in pre-2.0 versions of the Graylog web interface.
+web_listen_uri = http://10.0.0.50:9000/
+
+# Web interface endpoint URI. This setting can be overriden on a per-request basis with the X-Graylog-Server-URL header.
+# Default: $rest_transport_uri
+#web_endpoint_uri =
+
+# Enable CORS headers for the web interface. This is necessary for JS-clients accessing the server directly.
+# If these are disabled, modern browsers will not be able to retrieve resources from the server.
+#web_enable_cors = false
+
+# Enable/disable GZIP support for the web interface. This compresses HTTP responses and therefore helps to reduce
+# overall round trip times. This is enabled by default. Uncomment the next line to disable it.
+#web_enable_gzip = false
+
+# Enable HTTPS support for the web interface. This secures the communication of the web browser with the web interface
+# using TLS to prevent request forgery and eavesdropping.
+# This is disabled by default. Uncomment the next line to enable it and see the other related configuration settings.
+#web_enable_tls = true
+
+# The X.509 certificate chain file in PEM format to use for securing the web interface.
+#web_tls_cert_file = /path/to/graylog-web.crt
+
+# The PKCS#8 private key file in PEM format to use for securing the web interface.
+#web_tls_key_file = /path/to/graylog-web.key
+
+# The password to unlock the private key used for securing the web interface.
+#web_tls_key_password = secret
+
+# The maximum size of the HTTP request headers in bytes.
+#web_max_header_size = 8192
+
+# The maximal length of the initial HTTP/1.1 line in bytes.
+#web_max_initial_line_length = 4096
+
+# The size of the thread pool used exclusively for serving the web interface.
+#web_thread_pool_size = 16
+
+# Configuration file for the embedded Elasticsearch instance in Graylog.
+# Pay attention to the working directory of the server, maybe use an absolute path here.
+# Default: empty
+#elasticsearch_config_file = /etc/graylog/server/elasticsearch.yml
+
+# Graylog will use multiple indices to store documents in. You can configured the strategy it uses to determine
+# when to rotate the currently active write index.
+# It supports multiple rotation strategies:
+#   - "count" of messages per index, use elasticsearch_max_docs_per_index below to configure
+#   - "size" per index, use elasticsearch_max_size_per_index below to configure
+# valid values are "count", "size" and "time", default is "count"
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+rotation_strategy = count
+
+# (Approximate) maximum number of documents in an Elasticsearch index before a new index
+# is being created, also see no_retention and elasticsearch_max_number_of_indices.
+# Configure this if you used 'rotation_strategy = count' above.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+elasticsearch_max_docs_per_index = 20000000
+
+# (Approximate) maximum size in bytes per Elasticsearch index on disk before a new index is being created, also see
+# no_retention and elasticsearch_max_number_of_indices. Default is 1GB.
+# Configure this if you used 'rotation_strategy = size' above.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+#elasticsearch_max_size_per_index = 1073741824
+
+# (Approximate) maximum time before a new Elasticsearch index is being created, also see
+# no_retention and elasticsearch_max_number_of_indices. Default is 1 day.
+# Configure this if you used 'rotation_strategy = time' above.
+# Please note that this rotation period does not look at the time specified in the received messages, but is
+# using the real clock value to decide when to rotate the index!
+# Specify the time using a duration and a suffix indicating which unit you want:
+#  1w  = 1 week
+#  1d  = 1 day
+#  12h = 12 hours
+# Permitted suffixes are: d for day, h for hour, m for minute, s for second.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+#elasticsearch_max_time_per_index = 1d
+
+# Disable checking the version of Elasticsearch for being compatible with this Graylog release.
+# WARNING: Using Graylog with unsupported and untested versions of Elasticsearch may lead to data loss!
+#elasticsearch_disable_version_check = true
+
+# Disable message retention on this node, i. e. disable Elasticsearch index rotation.
+#no_retention = false
+
+# How many indices do you want to keep?
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+elasticsearch_max_number_of_indices = 20
+
+# Decide what happens with the oldest indices when the maximum number of indices is reached.
+# The following strategies are availble:
+#   - delete # Deletes the index completely (Default)
+#   - close # Closes the index and hides it from the system. Can be re-opened later.
+#
+# ATTENTION: These settings have been moved to the database in 2.0. When you upgrade, make sure to set these
+#            to your previous 1.x settings so they will be migrated to the database!
+retention_strategy = delete
+
+# How many Elasticsearch shards and replicas should be used per index? Note that this only applies to newly created indices.
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+elasticsearch_shards = 4
+elasticsearch_replicas = 1
+
+# Prefix for all Elasticsearch indices and index aliases managed by Graylog.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+elasticsearch_index_prefix = graylog
+
+# Name of the Elasticsearch index template used by Graylog to apply the mandatory index mapping.
+# Default: graylog-internal
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+#elasticsearch_template_name = graylog-internal
+
+# Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only
+# be enabled with care. See also: http://docs.graylog.org/en/2.1/pages/queries.html
+allow_leading_wildcard_searches = false
+
+# Do you want to allow searches to be highlighted? Depending on the size of your messages this can be memory hungry and
+# should only be enabled after making sure your Elasticsearch cluster has enough memory.
+allow_highlighting = false
+
+# settings to be passed to elasticsearch's client (overriding those in the provided elasticsearch_config_file)
+# all these
+# this must be the same as for your Elasticsearch cluster
+elasticsearch_cluster_name = graylog
+
+# The prefix being used to generate the Elasticsearch node name which makes it easier to identify the specific Graylog
+# server running the embedded Elasticsearch instance. The node name will be constructed by concatenating this prefix
+# and the Graylog node ID (see node_id_file), for example "graylog-17052010-1234-5678-abcd-1337cafebabe".
+# Default: graylog-
+#elasticsearch_node_name_prefix = graylog-
+
+# A comma-separated list of Elasticsearch nodes which Graylog is using to connect to the Elasticsearch cluster,
+# see https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-discovery-zen.html for details.
+# Default: 127.0.0.1
+elasticsearch_discovery_zen_ping_unicast_hosts = 10.0.0.10, 10.0.0.20
+
+# Use multiple Elasticsearch nodes as seed
+elasticsearch_discovery_zen_ping_unicast_hosts = 10.0.0.10:9300, 10.0.0.20:9300
+
+# we don't want the Graylog server to store any data, or be master node
+#elasticsearch_node_master = false
+#elasticsearch_node_data = false
+
+# use a different port if you run multiple Elasticsearch nodes on one machine
+elasticsearch_transport_tcp_port = 9300
+
+# we don't need to run the embedded HTTP server here
+#elasticsearch_http_enabled = false
+
+# Change the following setting if you are running into problems with timeouts during Elasticsearch cluster discovery.
+# The setting is specified in milliseconds, the default is 5000ms (5 seconds).
+#elasticsearch_cluster_discovery_timeout = 5000
+
+# the following settings allow to change the bind addresses for the Elasticsearch client in Graylog
+# these settings are empty by default, letting Elasticsearch choose automatically,
+# override them here or in the 'elasticsearch_config_file' if you need to bind to a special address
+# refer to https://www.elastic.co/guide/en/elasticsearch/reference/2.3/modules-network.html
+# for special values here
+elasticsearch_network_host = 10.0.0.50
+#elasticsearch_network_bind_host = 
+#elasticsearch_network_publish_host = 
+
+# The total amount of time discovery will look for other Elasticsearch nodes in the cluster
+# before giving up and declaring the current node master.
+#elasticsearch_discovery_initial_state_timeout = 3s
+
+# Analyzer (tokenizer) to use for message and full_message field. The "standard" filter usually is a good idea.
+# All supported analyzers are: standard, simple, whitespace, stop, keyword, pattern, language, snowball, custom
+# Elasticsearch documentation: https://www.elastic.co/guide/en/elasticsearch/reference/2.3/analysis.html
+# Note that this setting only takes effect on newly created indices.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+elasticsearch_analyzer = standard
+
+# Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
+# calculations) based on a best-effort to restrict the runtime of Elasticsearch operations.
+# Default: 1m
+#elasticsearch_request_timeout = 1m
+
+# Global timeout for index optimization (force merge) requests.
+# Default: 1h
+#elasticsearch_index_optimization_timeout = 1h
+
+# Maximum number of concurrently running index optimization (force merge) jobs.
+# If you are using lots of different index sets, you might want to increase that number.
+# Default: 20
+#elasticsearch_index_optimization_jobs = 20
+
+# Time interval for index range information cleanups. This setting defines how often stale index range information
+# is being purged from the database.
+# Default: 1h
+#index_ranges_cleanup_interval = 1h
+
+# Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output
+# module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been
+# reached within output_flush_interval seconds, everything that is available will be flushed at once. Remember
+# that every outputbuffer processor manages its own batch and performs its own batch write calls.
+# ("outputbuffer_processors" variable)
+output_batch_size = 500
+
+# Flush interval (in seconds) for the Elasticsearch output. This is the maximum amount of time between two
+# batches of messages written to Elasticsearch. It is only effective at all if your minimum number of messages
+# for this time period is less than output_batch_size * outputbuffer_processors.
+output_flush_interval = 1
+
+# As stream outputs are loaded only on demand, an output which is failing to initialize will be tried over and
+# over again. To prevent this, the following configuration options define after how many faults an output will
+# not be tried again for an also configurable amount of seconds.
+output_fault_count_threshold = 5
+output_fault_penalty_seconds = 30
+
+# The number of parallel running processors.
+# Raise this number if your buffers are filling up.
+processbuffer_processors = 5
+outputbuffer_processors = 3
+
+#outputbuffer_processor_keep_alive_time = 5000
+#outputbuffer_processor_threads_core_pool_size = 3
+#outputbuffer_processor_threads_max_pool_size = 30
+
+# UDP receive buffer size for all message inputs (e. g. SyslogUDPInput).
+#udp_recvbuffer_sizes = 1048576
+
+# Wait strategy describing how buffer processors wait on a cursor sequence. (default: sleeping)
+# Possible types:
+#  - yielding
+#     Compromise between performance and CPU usage.
+#  - sleeping
+#     Compromise between performance and CPU usage. Latency spikes can occur after quiet periods.
+#  - blocking
+#     High throughput, low latency, higher CPU usage.
+#  - busy_spinning
+#     Avoids syscalls which could introduce latency jitter. Best when threads can be bound to specific CPU cores.
+processor_wait_strategy = blocking
+
+# Size of internal ring buffers. Raise this if raising outputbuffer_processors does not help anymore.
+# For optimum performance your LogMessage objects in the ring buffer should fit in your CPU L3 cache.
+# Must be a power of 2. (512, 1024, 2048, ...)
+ring_size = 65536
+
+inputbuffer_ring_size = 65536
+inputbuffer_processors = 2
+inputbuffer_wait_strategy = blocking
+
+# Enable the disk based message journal.
+message_journal_enabled = true
+
+# The directory which will be used to store the message journal. The directory must me exclusively used by Graylog and
+# must not contain any other files than the ones created by Graylog itself.
+#
+# ATTENTION:
+#   If you create a seperate partition for the journal files and use a file system creating directories like 'lost+found'
+#   in the root directory, you need to create a sub directory for your journal.
+#   Otherwise Graylog will log an error message that the journal is corrupt and Graylog will not start.
+message_journal_dir = data/journal
+
+# Journal hold messages before they could be written to Elasticsearch.
+# For a maximum of 12 hours or 5 GB whichever happens first.
+# During normal operation the journal will be smaller.
+#message_journal_max_age = 12h
+#message_journal_max_size = 5gb
+
+#message_journal_flush_age = 1m
+#message_journal_flush_interval = 1000000
+#message_journal_segment_age = 1h
+#message_journal_segment_size = 100mb
+
+# Number of threads used exclusively for dispatching internal events. Default is 2.
+#async_eventbus_processors = 2
+
+# How many seconds to wait between marking node as DEAD for possible load balancers and starting the actual
+# shutdown process. Set to 0 if you have no status checking load balancers in front.
+lb_recognition_period_seconds = 3
+
+# Journal usage percentage that triggers requesting throttling for this server node from load balancers. The feature is
+# disabled if not set.
+#lb_throttle_threshold_percentage = 95
+
+# Every message is matched against the configured streams and it can happen that a stream contains rules which
+# take an unusual amount of time to run, for example if its using regular expressions that perform excessive backtracking.
+# This will impact the processing of the entire server. To keep such misbehaving stream rules from impacting other
+# streams, Graylog limits the execution time for each stream.
+# The default values are noted below, the timeout is in milliseconds.
+# If the stream matching for one stream took longer than the timeout value, and this happened more than "max_faults" times
+# that stream is disabled and a notification is shown in the web interface.
+#stream_processing_timeout = 2000
+#stream_processing_max_faults = 3
+
+# Length of the interval in seconds in which the alert conditions for all streams should be checked
+# and alarms are being sent.
+#alert_check_interval = 60
+
+# Since 0.21 the Graylog server supports pluggable output modules. This means a single message can be written to multiple
+# outputs. The next setting defines the timeout for a single output module, including the default output module where all
+# messages end up.
+#
+# Time in milliseconds to wait for all message outputs to finish writing a single message.
+#output_module_timeout = 10000
+
+# Time in milliseconds after which a detected stale master node is being rechecked on startup.
+#stale_master_timeout = 2000
+
+# Time in milliseconds which Graylog is waiting for all threads to stop on shutdown.
+#shutdown_timeout = 30000
+
+# MongoDB connection string
+# See https://docs.mongodb.com/manual/reference/connection-string/ for details
+mongodb_uri = mongodb://10.0.0.30:27017/graylog
+
+# Authenticate against the MongoDB server
+#mongodb_uri = mongodb://grayloguser:secret@localhost:27017/graylog
+
+# Use a replica set instead of a single host
+#mongodb_uri = mongodb://grayloguser:secret@localhost:27017,localhost:27018,localhost:27019/graylog
+
+# Increase this value according to the maximum connections your MongoDB server can handle from a single client
+# if you encounter MongoDB connection problems.
+mongodb_max_connections = 1000
+
+# Number of threads allowed to be blocked by MongoDB connections multiplier. Default: 5
+# If mongodb_max_connections is 100, and mongodb_threads_allowed_to_block_multiplier is 5,
+# then 500 threads can block. More than that and an exception will be thrown.
+# http://api.mongodb.com/java/current/com/mongodb/MongoOptions.html#threadsAllowedToBlockForConnectionMultiplier
+mongodb_threads_allowed_to_block_multiplier = 5
+
+# Drools Rule File (Use to rewrite incoming log messages)
+# See: http://docs.graylog.org/en/2.1/pages/drools.html
+#rules_file = /etc/graylog/server/rules.drl
+
+# Email transport
+#transport_email_enabled = false
+#transport_email_hostname = mail.example.com
+#transport_email_port = 587
+#transport_email_use_auth = true
+#transport_email_use_tls = true
+#transport_email_use_ssl = true
+#transport_email_auth_username = you@example.com
+#transport_email_auth_password = secret
+#transport_email_subject_prefix = [graylog]
+#transport_email_from_email = graylog@example.com
+
+# Specify and uncomment this if you want to include links to the stream in your stream alert mails.
+# This should define the fully qualified base url to your web interface exactly the same way as it is accessed by your users.
+#transport_email_web_interface_url = https://graylog.example.com
+
+# The default connect timeout for outgoing HTTP connections.
+# Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).
+# Default: 5s
+#http_connect_timeout = 5s
+
+# The default read timeout for outgoing HTTP connections.
+# Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).
+# Default: 10s
+#http_read_timeout = 10s
+
+# The default write timeout for outgoing HTTP connections.
+# Values must be a positive duration (and between 1 and 2147483647 when converted to milliseconds).
+# Default: 10s
+#http_write_timeout = 10s
+
+# HTTP proxy for outgoing HTTP connections
+#http_proxy_uri =
+
+# Disable the optimization of Elasticsearch indices after index cycling. This may take some load from Elasticsearch
+# on heavily used systems with large indices, but it will decrease search performance. The default is to optimize
+# cycled indices.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+#disable_index_optimization = true
+
+# Optimize the index down to <= index_optimization_max_num_segments. A higher number may take some load from Elasticsearch
+# on heavily used systems with large indices, but it will decrease search performance. The default is 1.
+#
+# ATTENTION: These settings have been moved to the database in Graylog 2.2.0. When you upgrade, make sure to set these
+#            to your previous settings so they will be migrated to the database!
+#index_optimization_max_num_segments = 1
+
+# The threshold of the garbage collection runs. If GC runs take longer than this threshold, a system notification
+# will be generated to warn the administrator about possible problems with the system. Default is 1 second.
+#gc_warning_threshold = 1s
+
+# Connection timeout for a configured LDAP server (e. g. ActiveDirectory) in milliseconds.
+#ldap_connection_timeout = 2000
+
+# Disable the use of SIGAR for collecting system stats
+#disable_sigar = false
+
+# The default cache time for dashboard widgets. (Default: 10 seconds, minimum: 1 second)
+#dashboard_widget_default_cache_time = 10s
+
+# Automatically load content packs in "content_packs_dir" on the first start of Graylog.
+#content_packs_loader_enabled = true
+
+# The directory which contains content packs which should be loaded on the first start of Graylog.
+#content_packs_dir = data/contentpacks
+
+# A comma-separated list of content packs (files in "content_packs_dir") which should be applied on
+# the first start of Graylog.
+# Default: empty
+content_packs_auto_load = grok-patterns.json
+
+# For some cluster-related REST requests, the node must query all other nodes in the cluster. This is the maximum number
+# of threads available for this. Increase it, if '/cluster/*' requests take long to complete.
+# Should be rest_thread_pool_size * average_cluster_size if you have a high number of concurrent users.
+proxied_requests_thread_pool_size = 32

--- a/vagrant/conf/nginx/nginx.conf
+++ b/vagrant/conf/nginx/nginx.conf
@@ -1,0 +1,38 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+  upstream graylog {
+    server 10.0.0.40:9000;
+    server 10.0.0.50:9000;
+    zone graylog 64k;
+  }
+
+  server {
+    listen 80;
+    server_name _;
+
+    location / {
+      proxy_pass            http://graylog;
+      proxy_set_header      X-Real-IP $remote_addr;
+      proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header      Host $http_host;
+      proxy_set_header      X-Forwarded-Proto $scheme;
+    }
+  }
+}
+
+stream {
+  upstream graylog_gelf_udp {
+    server 10.0.0.40:12201;
+    server 10.0.0.50:12201;
+    zone graylog_gelf_udp 64k;
+  }
+
+  server {
+    listen 12201 udp;
+    proxy_pass graylog_gelf_udp;
+    proxy_timeout 10s;
+  }
+}


### PR DESCRIPTION
# Changes

Create Vagrantfile spinning up:

- Elasticsearch cluster
- Graylog master and slave
- MongoDB (without Replica Set)
- Nginx as a load balancer for Graylog Web Interface and GELF UDP